### PR TITLE
change Fakeimg source to actual

### DIFF
--- a/src/FakeimgProvider.php
+++ b/src/FakeimgProvider.php
@@ -70,7 +70,7 @@ class FakeimgProvider extends BaseProvider
 
 
         return sprintf(
-            'https://fakeimg.pl/%dx%d/%s/%s%s',
+            'https://fakeimg.ryd.tools/%dx%d/%s/%s%s',
             $width,
             $height,
             self::colorToString($backgroundColor, 'CCCCCC'),


### PR DESCRIPTION
the source has been temporarily changed to https://fakeimg.ryd.tools due to the fact that the previous domain was lost
https://github.com/sainnhe/everforest/issues/158
https://github.com/Rydgel/Fake-images-please/issues/62#issuecomment-2910739372